### PR TITLE
fix: pin wipe cron minute to 0 (was firing every minute of wipe hour)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## 0.0.7
+* Fix wipe cron firing every minute of the wipe hour (the `minute` field defaulted to `*`); now defaults to `0` and is configurable via `rust_gameserver_wipe_minute_of_hour`
+
+## 0.0.6
 * Fixed paths so multiple server configs don't all show up in each others containers
 * Fixed paths for plugins
 * Separate oxide plugings / config and dll plugins if multiple servers

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.0.6
+version: 0.0.7
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -22,6 +22,7 @@ rust_gameserver_url: https://discord.gg/t77M3yAgKu
 rust_gameserver_banner_url: https://images2.imgbox.com/37/6d/fOpdrpYS_o.jpeg
 rust_gameserver_wipe_day_of_week: 4
 rust_gameserver_wipe_hour_of_day: 19
+rust_gameserver_wipe_minute_of_hour: 0
 rust_gameserver_wipe: "weekly" # can be monthly,biweekly,or weekly
 rust_gameserver_wipe_bp: 1 # whether or not to wipe blueprint (defaults to true)
 rust_gameserver_timezone: "America/Los_Angeles"

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -44,6 +44,7 @@
     name: "rust_wipe_{{ rust_gameserver_identity }}"
     job: "bash /etc/rust/server/{{ rust_gameserver_identity }}/wipe.sh"
     cron_file: "rust_wipe_{{ rust_gameserver_identity }}"
+    minute: "{{ rust_gameserver_wipe_minute_of_hour }}"
     hour: "{{ rust_gameserver_wipe_hour_of_day }}"
     weekday: "{{ rust_gameserver_wipe_day_of_week }}"
     user: root


### PR DESCRIPTION
## Summary
- The wipe cron only specified `hour` and `weekday`; `ansible.builtin.cron` defaults the unspecified `minute` field to `*`, so the cron expanded to e.g. `* 19 * * 4` and fired every minute from 19:00 to 19:59 on wipe day — restarting/re-wiping the server ~60 times.
- Added `rust_gameserver_wipe_minute_of_hour` (default `0`) and wired it into the cron task so wipes fire once per wipe day at the top of the hour.
- Bumped `galaxy.yml` to `0.0.7` and added a 0.0.7 entry to the changelog.

## Test plan
- [ ] Re-apply the role to a host and confirm `/etc/cron.d/rust_wipe_<identity>` reads `0 19 * * 4 root bash …` (not `* 19 * * 4 …`)
- [ ] Override `rust_gameserver_wipe_minute_of_hour: 30` and confirm the resulting cron uses `30 19 * * 4`
- [ ] Confirm wipe runs exactly once on the configured day/hour rather than continuously throughout the hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)