### PR TITLE
Add rust_gameserver_healthcheck_disabled flag to override image HEALTHCHECK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+* Added `rust_gameserver_healthcheck_disabled` to override the image's HEALTHCHECK on hosts whose Docker manager ignores `start_period` and kills the container mid-install
 * Fixed paths so multiple server configs don't all show up in each others containers
 * Fixed paths for plugins
 * Separate oxide plugings / config and dll plugins if multiple servers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Added `rust_gameserver_healthcheck_disabled` to override the image's HEALTHCHECK on hosts whose Docker manager ignores `start_period` and kills the container mid-install
 * Fixed paths so multiple server configs don't all show up in each others containers
 * Fixed paths for plugins
-* Separate oxide plugings / config and dll plugins if multiple servers
+* Separate oxide plugins / config and dll plugins if multiple servers
 * Updated documentation
 * Set oxide enabled by default
 * First release

--- a/roles/rust_gameserver/README.md
+++ b/roles/rust_gameserver/README.md
@@ -51,5 +51,5 @@ rust_gameserver_wipe_hour_of_day        | The time of day the server wipes on
 rust_gameserver_wipe                    | monthly, biweekly, or weekly
 rust_gameserver_timezone                | The timezone string (ex, "America/Los Angeles")
 rust_gameserver_wipe_bp                 | Whether or not to wipe blueprints
-rust_gameserver_seed                    | Starting seed for the first wipe. The wipe script will pick random
+rust_gameserver_seed                    | Starting seed for the first wipe. If omitted or set to `0`, the wipe script will pick a random seed.
 rust_gameserver_healthcheck_disabled    | Set to `true` to override the image's HEALTHCHECK with `["NONE"]`. Useful on hosts where a third-party Docker manager (e.g. UGREEN NAS) ignores the image's `start_period` and kills the container mid-install when the rcon-based health probe fails. Default `false`.

--- a/roles/rust_gameserver/README.md
+++ b/roles/rust_gameserver/README.md
@@ -52,3 +52,4 @@ rust_gameserver_wipe                    | monthly, biweekly, or weekly
 rust_gameserver_timezone                | The timezone string (ex, "America/Los Angeles")
 rust_gameserver_wipe_bp                 | Whether or not to wipe blueprints
 rust_gameserver_seed                    | Starting seed for the first wipe. The wipe script will pick random
+rust_gameserver_healthcheck_disabled    | Set to `true` to override the image's HEALTHCHECK with `["NONE"]`. Useful on hosts where a third-party Docker manager (e.g. UGREEN NAS) ignores the image's `start_period` and kills the container mid-install when the rcon-based health probe fails. Default `false`.

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -26,3 +26,18 @@ rust_gameserver_wipe: "weekly" # can be monthly,biweekly,or weekly
 rust_gameserver_wipe_bp: 1 # whether or not to wipe blueprint (defaults to true)
 rust_gameserver_timezone: "America/Los_Angeles"
 rust_gameserver_seed: 50000
+# Disable the image-defined HEALTHCHECK on the container.
+#
+# The upstream rust-server image ships a healthcheck that runs `rcon test` on a
+# 30s interval and treats `RconApp::Error` as unhealthy. Docker itself respects
+# the image's `start_period` (15min) and won't mark the container unhealthy
+# while the steam install is still running — but some third-party Docker
+# managers (notably UGREEN NAS's `docker_serv`, observed killing containers
+# via SIGKILL ~17s after a failed health probe regardless of `start_period`)
+# don't. On those systems the container gets killed mid-install on every
+# cycle and the server never finishes booting.
+#
+# Set this to `true` to override the image's healthcheck with `["NONE"]`,
+# which Docker treats as "no healthcheck". You'll lose the unhealthy-marker
+# signal in `docker ps`, but the container will be allowed to finish booting.
+rust_gameserver_healthcheck_disabled: false

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -78,4 +78,10 @@
       - /dev/dri:/dev/dri
     restart_policy: unless-stopped
     memory: 20g
+    # The image ships a HEALTHCHECK that runs `rcon test` and reports unhealthy
+    # while RCON is starting up. Docker respects `start_period`, but some
+    # third-party container managers (e.g. UGREEN NAS's docker_serv) don't and
+    # will kill the container mid-install. When this is set, override the
+    # image's healthcheck with `["NONE"]` so it's effectively disabled.
+    healthcheck: "{{ {'test': ['NONE']} if rust_gameserver_healthcheck_disabled else omit }}"
   when: not (rust_gameserver_molecule_test | default(false))


### PR DESCRIPTION
## Summary

The `ghcr.io/compscidr/rust-server` image ships a `HEALTHCHECK` that runs `rcon test` and reports unhealthy while RCON is still coming up:

```
HEALTHCHECK --start-period=15min --retries=1 \
  CMD bash -c 'if rcon test | grep -q "RconApp::Error"; then exit 1; else exit 0; fi'
```

Docker itself respects `start_period` and won't mark the container unhealthy during the first 15 minutes — that's enough room for the initial steam install (~5 min) plus RustDedicated startup. So under stock Docker the existing healthcheck works fine.

But not every container runtime respects `start_period`. **UGREEN NAS's `docker_serv`** does not — it issues a `SIGKILL` to the container roughly 17s after every failed health probe, regardless of `start_period`. On those hosts the container cycle looks like this:

```
1778120444 exec_create healthcheck
1778120444 exec_start  healthcheck
1778120444 exec_die 1   ← rcon not ready yet, normal
1778120461 kill         ← docker_serv kills it ~17s later
1778120464 stop / die
1778120465 start        ← back to steamcmd extraction from scratch
```

Result: the steam install never finishes, the server never boots, the container loops indefinitely.

## Change

Add a default-false `rust_gameserver_healthcheck_disabled` variable. When set to `true`, the role passes `healthcheck: { test: ['NONE'] }` through to `docker_container`, which Docker treats as "no healthcheck". The container is allowed to boot to completion. You lose the unhealthy-marker signal in `docker ps`, but that's a fair trade on a host where the marker triggers a kill loop.

Default behavior is unchanged.

## Files
- `roles/rust_gameserver/defaults/main.yml` — adds the variable + a comment explaining when to flip it
- `roles/rust_gameserver/tasks/main.yml` — wires it through to the docker_container task using `omit` so it's a no-op by default
- `roles/rust_gameserver/README.md` — documents the variable
- `CHANGELOG.md` — entry

## Test plan
- [x] Default unchanged (`omit` on the healthcheck key means docker_container doesn't override the image's healthcheck).
- [x] When `rust_gameserver_healthcheck_disabled: true`, the deployed container has `Config.Healthcheck.Test = ["NONE"]`.
- [x] On a UGREEN NAS, with the flag enabled, the rust-monthly container completes the steam install and brings RCON up on its configured port (verified manually before opening this PR).

## Long-term

The image's healthcheck itself could be smarter — e.g., distinguish "rcon not yet listening" (still installing, OK) from "rcon listening but returning errors" (actually unhealthy). That fix belongs in the `compscidr/rust-server` image repo. This PR just gives operators a way to opt out at the role level today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)