### PR TITLE
Optional wipe cron + env overwrite; seed.env create-only (0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.1.0
+* `seed.env` is now create-only (never overwritten by deploys) for all users — `wipe.sh` rotates the seed at runtime, so re-templating it on deploy could silently change the map on the next restart
+* New flag `rust_gameserver_manage_wipe_cron` (default `true`): set `false` when an external manager (e.g. rustd.xyz) owns wipes — the wipe cron is removed and `wipe.sh` is not installed
+* New flag `rust_gameserver_overwrite_env` (default `true`): set `false` to make `rust.env` bootstrap-only so runtime-managed settings survive deploys
+
 ## 0.0.7
 * Fix wipe cron firing every minute of the wipe hour (the `minute` field defaulted to `*`); now defaults to `0` and is configurable via `rust_gameserver_wipe_minute_of_hour`
 * Added `rust_gameserver_healthcheck_disabled` to override the image's HEALTHCHECK on hosts whose Docker manager ignores `start_period` and kills the container mid-install

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.0.7
+version: 0.1.0
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -21,34 +21,3 @@
         rust_gameserver_wipe_day_of_week: 4
         rust_gameserver_wipe_hour_of_day: 19
         rust_gameserver_molecule_test: true
-
-- name: Mutate runtime-managed files (simulating wipe.sh / an external manager)
-  hosts: all
-  become: true
-  tasks:
-    - name: Rotate the seed like wipe.sh does
-      ansible.builtin.copy:
-        content: 'RUST_SERVER_SEED="99999"'
-        dest: /etc/rust/server/test/seed.env
-        mode: '644'
-    - name: Drift rust.env like an external manager would
-      ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
-        regexp: '^RUST_SERVER_NAME='
-        line: 'RUST_SERVER_NAME="Renamed At Runtime"'
-
-- name: Re-converge with default flags
-  hosts: all
-  become: true
-  tasks:
-    - name: Re-include rust_gameserver role
-      ansible.builtin.include_role:
-        name: rust_gameserver
-      vars:
-        rust_gameserver_identity: "test"
-        rust_gameserver_name: "Test Server"
-        rust_gameserver_description: "Molecule Test Server"
-        rust_gameserver_rcon_password: "testpass"
-        rust_gameserver_wipe_day_of_week: 4
-        rust_gameserver_wipe_hour_of_day: 19
-        rust_gameserver_molecule_test: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -68,3 +68,26 @@
         that:
           - cron_file_check.stat.exists
           - cron_file_check.stat.isreg
+
+    - name: Read seed.env after re-converge
+      ansible.builtin.slurp:
+        src: /etc/rust/server/test/seed.env
+      register: seed_env_content
+
+    - name: Assert the rotated seed survived the re-run (create-only semantics)
+      ansible.builtin.assert:
+        that:
+          - "'99999' in (seed_env_content.content | b64decode)"
+
+    - name: Check rust.env drift was overwritten (default overwrite_env)
+      ansible.builtin.lineinfile:
+        path: /etc/rust/server/test/rust.env
+        line: 'RUST_SERVER_NAME="Test Server"'
+        state: present
+      check_mode: true
+      register: rust_env_restored
+
+    - name: Assert rust.env was re-templated over the drift
+      ansible.builtin.assert:
+        that:
+          - not rust_env_restored.changed

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,6 +4,30 @@
   gather_facts: false
   become: true
   tasks:
+    - name: Rotate the seed like wipe.sh does
+      ansible.builtin.copy:
+        content: 'RUST_SERVER_SEED="99999"'
+        dest: /etc/rust/server/test/seed.env
+        mode: '644'
+
+    - name: Drift rust.env like an external manager would
+      ansible.builtin.lineinfile:
+        path: /etc/rust/server/test/rust.env
+        regexp: '^RUST_SERVER_NAME='
+        line: 'RUST_SERVER_NAME="Renamed At Runtime"'
+
+    - name: Re-include rust_gameserver role
+      ansible.builtin.include_role:
+        name: rust_gameserver
+      vars:
+        rust_gameserver_identity: "test"
+        rust_gameserver_name: "Test Server"
+        rust_gameserver_description: "Molecule Test Server"
+        rust_gameserver_rcon_password: "testpass"
+        rust_gameserver_wipe_day_of_week: 4
+        rust_gameserver_wipe_hour_of_day: 19
+        rust_gameserver_molecule_test: true
+
     - name: Verify rust config directories exist
       ansible.builtin.stat:
         path: "{{ item }}"

--- a/molecule/external/converge.yml
+++ b/molecule/external/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge
+- name: Converge with defaults first (simulates an existing cron-managed install)
   hosts: all
   become: true
   pre_tasks:
@@ -8,9 +8,8 @@
         update_cache: true
         cache_valid_time: 600
       when: ansible_os_family == "Debian"
-
   tasks:
-    - name: Include rust_gameserver role
+    - name: Include rust_gameserver role with defaults
       ansible.builtin.include_role:
         name: rust_gameserver
       vars:
@@ -18,30 +17,23 @@
         rust_gameserver_name: "Test Server"
         rust_gameserver_description: "Molecule Test Server"
         rust_gameserver_rcon_password: "testpass"
-        rust_gameserver_wipe_day_of_week: 4
-        rust_gameserver_wipe_hour_of_day: 19
         rust_gameserver_molecule_test: true
 
-- name: Mutate runtime-managed files (simulating wipe.sh / an external manager)
+- name: Drift rust.env like an external manager would
   hosts: all
   become: true
   tasks:
-    - name: Rotate the seed like wipe.sh does
-      ansible.builtin.copy:
-        content: 'RUST_SERVER_SEED="99999"'
-        dest: /etc/rust/server/test/seed.env
-        mode: '644'
-    - name: Drift rust.env like an external manager would
+    - name: Change the server name in rust.env
       ansible.builtin.lineinfile:
         path: /etc/rust/server/test/rust.env
         regexp: '^RUST_SERVER_NAME='
-        line: 'RUST_SERVER_NAME="Renamed At Runtime"'
+        line: 'RUST_SERVER_NAME="Panel Managed Name"'
 
-- name: Re-converge with default flags
+- name: Re-converge in external-manager mode
   hosts: all
   become: true
   tasks:
-    - name: Re-include rust_gameserver role
+    - name: Include rust_gameserver role with panel-mode flags
       ansible.builtin.include_role:
         name: rust_gameserver
       vars:
@@ -49,6 +41,6 @@
         rust_gameserver_name: "Test Server"
         rust_gameserver_description: "Molecule Test Server"
         rust_gameserver_rcon_password: "testpass"
-        rust_gameserver_wipe_day_of_week: 4
-        rust_gameserver_wipe_hour_of_day: 19
         rust_gameserver_molecule_test: true
+        rust_gameserver_manage_wipe_cron: false
+        rust_gameserver_overwrite_env: false

--- a/molecule/external/converge.yml
+++ b/molecule/external/converge.yml
@@ -1,5 +1,5 @@
 ---
-- name: Converge with defaults first (simulates an existing cron-managed install)
+- name: Converge with defaults (simulates an existing cron-managed install)
   hosts: all
   become: true
   pre_tasks:
@@ -18,29 +18,3 @@
         rust_gameserver_description: "Molecule Test Server"
         rust_gameserver_rcon_password: "testpass"
         rust_gameserver_molecule_test: true
-
-- name: Drift rust.env like an external manager would
-  hosts: all
-  become: true
-  tasks:
-    - name: Change the server name in rust.env
-      ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
-        regexp: '^RUST_SERVER_NAME='
-        line: 'RUST_SERVER_NAME="Panel Managed Name"'
-
-- name: Re-converge in external-manager mode
-  hosts: all
-  become: true
-  tasks:
-    - name: Include rust_gameserver role with panel-mode flags
-      ansible.builtin.include_role:
-        name: rust_gameserver
-      vars:
-        rust_gameserver_identity: "test"
-        rust_gameserver_name: "Test Server"
-        rust_gameserver_description: "Molecule Test Server"
-        rust_gameserver_rcon_password: "testpass"
-        rust_gameserver_molecule_test: true
-        rust_gameserver_manage_wipe_cron: false
-        rust_gameserver_overwrite_env: false

--- a/molecule/external/molecule.yml
+++ b/molecule/external/molecule.yml
@@ -1,0 +1,39 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-ubuntu2404-ansible:latest"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    pre_build_image: true
+    tmpfs:
+      - /tmp
+      - /run
+    capabilities:
+      - SYS_ADMIN
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      instance:
+        # Override defaults for testing - use /tmp for test directories
+        rust_gameserver_identity: "test"
+        rust_gameserver_port: 28015
+        rust_gameserver_rcon_port: 28016
+        rust_gameserver_query_port: 28017
+        rust_gameserver_rcon_web_port: 28018
+        rust_gameserver_app_port: 28083
+        rust_gameserver_timezone: "UTC"
+        rust_gameserver_wipe_hour_of_day: 12
+        rust_gameserver_wipe_day_of_week: 1
+        # Skip docker installation since we're testing in CI
+        rust_gameserver_molecule_test: true
+verifier:
+  name: ansible

--- a/molecule/external/verify.yml
+++ b/molecule/external/verify.yml
@@ -4,6 +4,24 @@
   gather_facts: false
   become: true
   tasks:
+    - name: Change the server name in rust.env
+      ansible.builtin.lineinfile:
+        path: /etc/rust/server/test/rust.env
+        regexp: '^RUST_SERVER_NAME='
+        line: 'RUST_SERVER_NAME="Panel Managed Name"'
+
+    - name: Include rust_gameserver role with panel-mode flags
+      ansible.builtin.include_role:
+        name: rust_gameserver
+      vars:
+        rust_gameserver_identity: "test"
+        rust_gameserver_name: "Test Server"
+        rust_gameserver_description: "Molecule Test Server"
+        rust_gameserver_rcon_password: "testpass"
+        rust_gameserver_molecule_test: true
+        rust_gameserver_manage_wipe_cron: false
+        rust_gameserver_overwrite_env: false
+
     - name: Check the wipe cron file
       ansible.builtin.stat:
         path: /etc/cron.d/rust_wipe_test

--- a/molecule/external/verify.yml
+++ b/molecule/external/verify.yml
@@ -1,0 +1,38 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Check the wipe cron file
+      ansible.builtin.stat:
+        path: /etc/cron.d/rust_wipe_test
+      register: cron_file_check
+
+    - name: Assert the previously-installed cron was REMOVED
+      ansible.builtin.assert:
+        that:
+          - not cron_file_check.stat.exists
+
+    - name: Check panel-drifted rust.env survived
+      ansible.builtin.lineinfile:
+        path: /etc/rust/server/test/rust.env
+        line: 'RUST_SERVER_NAME="Panel Managed Name"'
+        state: present
+      check_mode: true
+      register: drift_check
+
+    - name: Assert rust.env was NOT re-templated (overwrite_env false)
+      ansible.builtin.assert:
+        that:
+          - not drift_check.changed
+
+    - name: Check seed.env still exists
+      ansible.builtin.stat:
+        path: /etc/rust/server/test/seed.env
+      register: seed_check
+
+    - name: Assert seed.env exists (created by first run, untouched after)
+      ansible.builtin.assert:
+        that:
+          - seed_check.stat.exists

--- a/roles/rust_gameserver/README.md
+++ b/roles/rust_gameserver/README.md
@@ -54,3 +54,18 @@ rust_gameserver_timezone                | The timezone string (ex, "America/Los 
 rust_gameserver_wipe_bp                 | Whether or not to wipe blueprints
 rust_gameserver_seed                    | Starting seed for the first wipe. If omitted or set to `0`, the wipe script will pick a random seed.
 rust_gameserver_healthcheck_disabled    | Set to `true` to override the image's HEALTHCHECK with `["NONE"]`. Useful on hosts where a third-party Docker manager (e.g. UGREEN NAS) ignores the image's `start_period` and kills the container mid-install when the rcon-based health probe fails. Default `false`.
+
+## Management modes
+
+By default this role is authoritative: every run re-templates `rust.env` and
+installs the wipe cron. If you manage the server at runtime with an external
+tool (for example [rustd.xyz](https://github.com/compscidr/rustd.xyz)), set:
+
+```yaml
+rust_gameserver_manage_wipe_cron: false  # removes the cron; your tool owns wipes
+rust_gameserver_overwrite_env: false     # rust.env written once at install, never overwritten
+```
+
+`seed.env` is always create-only regardless of these flags: the wipe script and
+external managers both rotate the seed at runtime, and a deploy must never
+revert it (that would change the map on the next restart).

--- a/roles/rust_gameserver/README.md
+++ b/roles/rust_gameserver/README.md
@@ -54,6 +54,8 @@ rust_gameserver_timezone                | The timezone string (ex, "America/Los 
 rust_gameserver_wipe_bp                 | Whether or not to wipe blueprints
 rust_gameserver_seed                    | Starting seed for the first wipe. If omitted or set to `0`, the wipe script will pick a random seed.
 rust_gameserver_healthcheck_disabled    | Set to `true` to override the image's HEALTHCHECK with `["NONE"]`. Useful on hosts where a third-party Docker manager (e.g. UGREEN NAS) ignores the image's `start_period` and kills the container mid-install when the rcon-based health probe fails. Default `false`.
+rust_gameserver_manage_wipe_cron        | Whether this role installs the wipe cron + `wipe.sh` (default `true`). Set `false` when an external manager (e.g. rustd.xyz) owns wipes — the cron is removed. See "Management modes" below.
+rust_gameserver_overwrite_env           | Whether `rust.env` is re-templated on every run (default `true`). Set `false` to make it bootstrap-only so runtime-managed settings survive deploys. See "Management modes" below.
 
 ## Management modes
 

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -42,3 +42,11 @@ rust_gameserver_seed: 50000
 # which Docker treats as "no healthcheck". You'll lose the unhealthy-marker
 # signal in `docker ps`, but the container will be allowed to finish booting.
 rust_gameserver_healthcheck_disabled: false
+# When true (default), the wipe cron + wipe.sh are installed. Set false when an
+# external manager (e.g. rustd.xyz) owns wipes: the cron is REMOVED and wipe.sh
+# is not templated.
+rust_gameserver_manage_wipe_cron: true
+# When true (default), rust.env is re-templated on every run (Ansible is
+# authoritative). Set false to write it only when absent (bootstrap-only), so a
+# runtime manager can own name/description/etc. without deploys reverting them.
+rust_gameserver_overwrite_env: true

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -17,22 +17,41 @@
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
 
-- name: Copy configs to host
+- name: Copy rust.env to host
   tags: rust_gameserver
   become: true
   ansible.builtin.template:
-    src: "{{ item.src }}"
-    dest: "{{ item.dest }}"
+    src: rust.env.j2
+    dest: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
     mode: '644'
     owner: root
     group: root
-  loop:
-    - src: rust.env.j2
-      dest: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
-    - src: seed.env.j2
-      dest: /etc/rust/server/{{ rust_gameserver_identity }}/seed.env
-    - src: wipe.sh.j2
-      dest: /etc/rust/server/{{ rust_gameserver_identity }}/wipe.sh
+    force: "{{ rust_gameserver_overwrite_env }}"
+
+# seed.env is deliberately create-only for EVERYONE: wipe.sh rotates the seed at
+# runtime, so re-templating it on deploy would silently change the map on the
+# next server restart (accidental wipe).
+- name: Create seed.env on host (never overwritten)
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.template:
+    src: seed.env.j2
+    dest: /etc/rust/server/{{ rust_gameserver_identity }}/seed.env
+    mode: '644'
+    owner: root
+    group: root
+    force: false
+
+- name: Copy wipe.sh to host
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.template:
+    src: wipe.sh.j2
+    dest: /etc/rust/server/{{ rust_gameserver_identity }}/wipe.sh
+    mode: '644'
+    owner: root
+    group: root
+  when: rust_gameserver_manage_wipe_cron
 
 # this should fire every week on the day of the week specified at the time
 # and then the wipe script will determine whether or not to actually wipe
@@ -48,6 +67,7 @@
     hour: "{{ rust_gameserver_wipe_hour_of_day }}"
     weekday: "{{ rust_gameserver_wipe_day_of_week }}"
     user: root
+    state: "{{ 'present' if rust_gameserver_manage_wipe_cron else 'absent' }}"
 
 - name: Deploy rust server
   become: true

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -17,15 +17,18 @@
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
 
+# rust.env carries RUST_RCON_PASSWORD — not world-readable. Group 1000 matches the
+# PUID/PGID the container runs with, so both the container entrypoint (root) and the
+# dropped game user can read it while other host users cannot.
 - name: Copy rust.env to host
   tags: rust_gameserver
   become: true
   ansible.builtin.template:
     src: rust.env.j2
     dest: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
-    mode: '644'
+    mode: '640'
     owner: root
-    group: root
+    group: "1000"
     force: "{{ rust_gameserver_overwrite_env }}"
 
 # seed.env is deliberately create-only for EVERYONE: wipe.sh rotates the seed at


### PR DESCRIPTION
Two independent flags, both defaulting to current behavior:

- `rust_gameserver_manage_wipe_cron` (default `true`) — `false` removes the wipe cron (`state: absent`) and skips `wipe.sh`, for servers whose wipes are owned by an external manager (e.g. rustd.xyz).
- `rust_gameserver_overwrite_env` (default `true`) — `false` makes `rust.env` bootstrap-only (written when absent, never overwritten), so runtime-managed settings survive deploys.

One deliberate behavior change for everyone (hence 0.0.7 → 0.1.0): **`seed.env` is now create-only.** `wipe.sh` rotates the seed at runtime, so deploy-time re-templating reverts it and silently changes the map on the next container restart — an accidental map wipe. (Live case: a drifted weekly server one deploy away from losing its map.)

Molecule: default scenario now verifies seed preservation + env re-templating under default flags; new `external` scenario verifies cron removal and env preservation in external-manager mode. Both scenarios pass `molecule test` end-to-end including idempotence (mutation coverage lives in verify.yml so converge stays idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)