### PR TITLE
Configurable runtime uid/gid; identity dirs owned by runtime user (0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.1.1
+* New `rust_gameserver_puid` / `rust_gameserver_pgid` vars (default `"1000"`): configure the container runtime uid/gid in one place — used for the container `PUID`/`PGID` env, per-identity directory ownership, and `rust.env` group
+* Per-identity config directories (`oxide/`, `oxide/plugins/`, `cfg/`, `RustDedicated_Data/`, `Managed/`) are now owned by the runtime user instead of root — Oxide and the server run as that uid and need to create files there (root-owned dirs silently broke plugin data writes and config rewrites)
+* `rust.env` permissions (640, root:pgid) are now enforced even on existing installs (the `force: false` bootstrap path previously skipped attribute changes)
+
 ## 0.1.0
 * `seed.env` is now create-only (never overwritten by deploys) for all users — `wipe.sh` rotates the seed at runtime, so re-templating it on deploy could silently change the map on the next restart
 * New flag `rust_gameserver_manage_wipe_cron` (default `true`): set `false` when an external manager (e.g. rustd.xyz) owns wipes — the wipe cron is removed and `wipe.sh` is not installed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -115,3 +115,26 @@
       ansible.builtin.assert:
         that:
           - not rust_env_restored.changed
+
+    - name: Stat oxide directory ownership
+      ansible.builtin.stat:
+        path: /etc/rust/server/test/oxide
+      register: oxide_dir_stat
+
+    - name: Assert identity directories are owned by the runtime user
+      ansible.builtin.assert:
+        that:
+          - oxide_dir_stat.stat.uid == 1000
+          - oxide_dir_stat.stat.gid == 1000
+
+    - name: Stat rust.env permissions
+      ansible.builtin.stat:
+        path: /etc/rust/server/test/rust.env
+      register: rust_env_stat
+
+    - name: Assert rust.env is 640 root:pgid (enforced even on the bootstrap path)
+      ansible.builtin.assert:
+        that:
+          - rust_env_stat.stat.mode == '0640'
+          - rust_env_stat.stat.uid == 0
+          - rust_env_stat.stat.gid == 1000

--- a/roles/rust_gameserver/README.md
+++ b/roles/rust_gameserver/README.md
@@ -56,6 +56,8 @@ rust_gameserver_seed                    | Starting seed for the first wipe. If o
 rust_gameserver_healthcheck_disabled    | Set to `true` to override the image's HEALTHCHECK with `["NONE"]`. Useful on hosts where a third-party Docker manager (e.g. UGREEN NAS) ignores the image's `start_period` and kills the container mid-install when the rcon-based health probe fails. Default `false`.
 rust_gameserver_manage_wipe_cron        | Whether this role installs the wipe cron + `wipe.sh` (default `true`). Set `false` when an external manager (e.g. rustd.xyz) owns wipes — the cron is removed. See "Management modes" below.
 rust_gameserver_overwrite_env           | Whether `rust.env` is re-templated on every run (default `true`). Set `false` to make it bootstrap-only so runtime-managed settings survive deploys. See "Management modes" below.
+rust_gameserver_puid                    | Runtime uid the container drops to (default `"1000"`); also owns the per-identity config directories and is used for file ownership
+rust_gameserver_pgid                    | Runtime gid (default `"1000"`); also the group on `rust.env` (mode 640) so the runtime user can read the RCON password while other host users cannot
 
 ## Management modes
 

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -50,3 +50,7 @@ rust_gameserver_manage_wipe_cron: true
 # authoritative). Set false to write it only when absent (bootstrap-only), so a
 # runtime manager can own name/description/etc. without deploys reverting them.
 rust_gameserver_overwrite_env: true
+# Runtime uid/gid the container drops to (PUID/PGID) — also owns the per-identity
+# config directories so Oxide/the server can create files there, and groups rust.env.
+rust_gameserver_puid: "1000"
+rust_gameserver_pgid: "1000"

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Create config directories
+- name: Create base config directories
   tags: rust_gameserver
   become: true
   ansible.builtin.file:
@@ -11,15 +11,28 @@
   loop:
     - /etc/rust
     - /etc/rust/server
+
+# Per-identity directories are owned by the container's runtime user (PUID/PGID):
+# Oxide and the game server run as that uid and need to CREATE files here (plugin
+# data, compiled artifacts, config rewrites) — root-owned 755 dirs break that.
+- name: Create server identity directories (owned by the runtime user)
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '755'
+    owner: "{{ rust_gameserver_puid }}"
+    group: "{{ rust_gameserver_pgid }}"
+  loop:
     - /etc/rust/server/{{ rust_gameserver_identity }}/oxide
     - /etc/rust/server/{{ rust_gameserver_identity }}/oxide/plugins
     - /etc/rust/server/{{ rust_gameserver_identity }}/cfg
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
 
-# rust.env carries RUST_RCON_PASSWORD — not world-readable. Group 1000 matches the
-# PUID/PGID the container runs with, so both the container entrypoint (root) and the
-# dropped game user can read it while other host users cannot.
+# rust.env carries RUST_RCON_PASSWORD — not world-readable. The runtime group can
+# read it (the container entrypoint and dropped game user), other host users cannot.
 - name: Copy rust.env to host
   tags: rust_gameserver
   become: true
@@ -28,8 +41,20 @@
     dest: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
     mode: '640'
     owner: root
-    group: "1000"
+    group: "{{ rust_gameserver_pgid }}"
     force: "{{ rust_gameserver_overwrite_env }}"
+
+# `force: false` above skips EVERYTHING when the file exists — including mode/owner.
+# This separate attributes-only task retrofits the not-world-readable fix onto
+# existing installs without ever touching the file's content.
+- name: Enforce rust.env permissions
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.file:
+    path: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
+    mode: '640'
+    owner: root
+    group: "{{ rust_gameserver_pgid }}"
 
 # seed.env is deliberately create-only for EVERYONE: wipe.sh rotates the seed at
 # runtime, so re-templating it on deploy would silently change the map on the
@@ -96,8 +121,8 @@
       - "{{ rust_gameserver_app_port }}:{{ rust_gameserver_app_port }}/udp"
     env:
       TZ: "{{ rust_gameserver_timezone }}"
-      PUID: "1000"
-      PGID: "1000"
+      PUID: "{{ rust_gameserver_puid }}"
+      PGID: "{{ rust_gameserver_pgid }}"
     devices:
       - /dev/dri:/dev/dri
     restart_policy: unless-stopped


### PR DESCRIPTION
Follow-up to #23, prompted by a real `--check` diff against a live host: the role was about to chown per-identity directories from `1000:1000` back to `root:root`, which breaks Oxide's ability to CREATE files (plugin data, compiled artifacts, config rewrites) since it runs as the container uid.

- New `rust_gameserver_puid` / `rust_gameserver_pgid` (default `"1000"`): one knob for the container `PUID`/`PGID` env, per-identity dir ownership (`oxide/`, `oxide/plugins/`, `cfg/`, `RustDedicated_Data/`, `Managed/`), and `rust.env`'s group. Top-level `/etc/rust`(+`/server`) stay root-owned.
- `rust.env` 640 permissions now enforced via a separate attributes-only task, so existing installs get the not-world-readable fix too (the `force: false` bootstrap path skips attribute changes on existing files).
- Molecule: default scenario asserts dir ownership and rust.env `0640 root:pgid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)