### PR TITLE
Runtime uid/gid, and let an external wipe manager write without root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.2.0
+* New `rust_gameserver_manager_users` (default `[]`): host users an external manager (e.g. rustd.xyz) connects as, appended to the container's runtime group so they can write inside the identity directory. Deliberately group membership rather than a sudo grant — such a manager's filesystem work is confined to that one directory tree and it drives the server lifecycle over RCON, so root is never required
+* New `rust_gameserver_identity_dir_mode` (default `'0755'`, unchanged behaviour): set `'2775'` alongside `rust_gameserver_manager_users`. The group-write bit lets the manager create snapshots and delete map/save files; **SETGID is load-bearing** — `sed -i` on `seed.env` replaces the file rather than editing it, and without setgid the replacement lands in the manager's own group, at which point the container can no longer read its own seed
+* `/etc/rust/server/<identity>` is now managed explicitly instead of appearing as a side effect of creating its children, which is what makes the mode above meaningful
+
 ## 0.1.1
 * New `rust_gameserver_puid` / `rust_gameserver_pgid` vars (default `"1000"`): configure the container runtime uid/gid in one place — used for the container `PUID`/`PGID` env, per-identity directory ownership, and `rust.env` group
 * Per-identity config directories (`oxide/`, `oxide/plugins/`, `cfg/`, `RustDedicated_Data/`, `Managed/`) are now owned by the runtime user instead of root — Oxide and the server run as that uid and need to create files there (root-owned dirs silently broke plugin data writes and config rewrites)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.1.1
+version: 0.2.0
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,11 @@
   hosts: all
   become: true
   pre_tasks:
+    - name: Create the manager user the role will add to the runtime group
+      ansible.builtin.user:
+        name: molecule_manager
+        create_home: false
+
     - name: Update apt cache
       ansible.builtin.apt:
         update_cache: true
@@ -18,6 +23,11 @@
         rust_gameserver_name: "Test Server"
         rust_gameserver_description: "Molecule Test Server"
         rust_gameserver_rcon_password: "testpass"
+        # Exercise the external-manager path: a manager user in the runtime group,
+        # and a setgid group-writable identity directory.
+        rust_gameserver_manager_users:
+          - "molecule_manager"
+        rust_gameserver_identity_dir_mode: '2775'
         rust_gameserver_wipe_day_of_week: 4
         rust_gameserver_wipe_hour_of_day: 19
         rust_gameserver_molecule_test: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -24,6 +24,14 @@
         rust_gameserver_name: "Test Server"
         rust_gameserver_description: "Molecule Test Server"
         rust_gameserver_rcon_password: "testpass"
+        # Must match converge exactly. Re-running the role WITHOUT these resets the
+        # identity directory to the default 0755 and revokes the manager's group write —
+        # which is precisely what this re-include caught, and is a real hazard: an
+        # operator who deploys from a context missing these vars silently locks the
+        # external manager out of the directory it needs.
+        rust_gameserver_manager_users:
+          - "molecule_manager"
+        rust_gameserver_identity_dir_mode: '2775'
         rust_gameserver_wipe_day_of_week: 4
         rust_gameserver_wipe_hour_of_day: 19
         rust_gameserver_molecule_test: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -138,3 +138,31 @@
           - rust_env_stat.stat.mode == '0640'
           - rust_env_stat.stat.uid == 0
           - rust_env_stat.stat.gid == 1000
+
+    - name: Stat the identity directory
+      ansible.builtin.stat:
+        path: /etc/rust/server/test
+      register: identity_dir_stat
+
+    - name: Assert the identity directory is group-writable and setgid
+      ansible.builtin.assert:
+        that:
+          - identity_dir_stat.stat.mode == '2775'
+          - identity_dir_stat.stat.gid == 1000
+        fail_msg: >-
+          The identity directory must be group-writable and SETGID. Without setgid,
+          `sed -i` on seed.env hands the replacement to the manager's own group and
+          the container can no longer read its own seed.
+
+    - name: Read the runtime group
+      ansible.builtin.getent:
+        database: group
+        key: "1000"
+
+    - name: Assert the manager user was added to the runtime group
+      ansible.builtin.assert:
+        that:
+          - "'molecule_manager' in (ansible_facts.getent_group | dict2items | first).value[2]"
+        fail_msg: >-
+          molecule_manager is not in the runtime group, so an external manager could
+          not write inside the identity directory without root.

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -54,3 +54,17 @@ rust_gameserver_overwrite_env: true
 # config directories so Oxide/the server can create files there, and groups rust.env.
 rust_gameserver_puid: "1000"
 rust_gameserver_pgid: "1000"
+
+# Host users that an external manager (e.g. rustd.xyz) connects as. Each is appended
+# to the runtime group so it can write inside the identity directory. Deliberately
+# NOT a sudo grant: everything such a manager does is confined to that one directory
+# tree, and it drives the server lifecycle over RCON, so root is never required.
+# Requires rust_gameserver_identity_dir_mode to allow group write.
+rust_gameserver_manager_users: []
+
+# Mode for /etc/rust/server/<identity>. Default matches the previous behaviour.
+# Set '2775' when rust_gameserver_manager_users is non-empty: group write lets the
+# manager create snapshots and delete map files, and SETGID keeps the runtime group
+# on files it replaces — without it, `sed -i` on seed.env hands the file to the
+# manager's own group and the container can no longer read its own seed.
+rust_gameserver_identity_dir_mode: '0755'

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -12,6 +12,55 @@
     - /etc/rust
     - /etc/rust/server
 
+# The identity directory itself is where an external manager (rustd.xyz) does its
+# work: it creates snapshot subdirectories, rewrites seed.env and deletes map/save
+# files here. Managing it explicitly — rather than letting it appear as a side effect
+# of creating its children — is what makes `rust_gameserver_identity_dir_mode` mean
+# anything.
+#
+# SETGID (the leading 2 in 2775) is load-bearing when a manager user writes here, and
+# is the reason this is a directory mode rather than a per-file grant: `sed -i` on
+# seed.env does not edit in place, it writes a temp file and renames over the target.
+# The replacement is owned by whoever ran it, and WITHOUT setgid it lands in that
+# user's own group — at which point the container (which runs as PGID and reads
+# seed.env by group) can no longer read its own seed. Setgid keeps the runtime group
+# on anything created here, so that failure cannot happen.
+# An external wipe manager (rustd.xyz) needs to create, rewrite and delete files in
+# the identity directory. It deliberately does NOT get root: everything it does is
+# confined to that one tree, and the server lifecycle it drives goes over RCON rather
+# than docker or systemd — so group membership is sufficient and a sudo grant would be
+# strictly more privilege than the job needs.
+#
+# Resolved from the numeric PGID rather than taking a group name as input, so this
+# cannot drift from the group the container actually runs as.
+- name: Resolve the runtime group name for manager users
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.getent:
+    database: group
+    key: "{{ rust_gameserver_pgid }}"
+  when: rust_gameserver_manager_users | length > 0
+
+- name: Add manager users to the runtime group
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.user:
+    name: "{{ item }}"
+    groups: "{{ ansible_facts.getent_group | first }}"
+    append: true
+  loop: "{{ rust_gameserver_manager_users }}"
+  when: rust_gameserver_manager_users | length > 0
+
+- name: Create the server identity directory
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.file:
+    path: /etc/rust/server/{{ rust_gameserver_identity }}
+    state: directory
+    mode: "{{ rust_gameserver_identity_dir_mode }}"
+    owner: "{{ rust_gameserver_puid }}"
+    group: "{{ rust_gameserver_pgid }}"
+
 # Per-identity directories are owned by the container's runtime user (PUID/PGID):
 # Oxide and the game server run as that uid and need to CREATE files here (plugin
 # data, compiled artifacts, config rewrites) — root-owned 755 dirs break that.


### PR DESCRIPTION
Two related commits. The first makes the container's runtime uid/gid configurable and gives the per-identity directories to that user. The second builds on it so rustd.xyz can do its filesystem work as an ordinary user.

## Why not sudo

rustd.xyz needs to create snapshot directories, rewrite `seed.env` and delete map/save files inside the identity directory. I checked every host-side operation it performs before choosing the mechanism:

```
stop/start server -> RCON "restart 30"   (no host access at all)
snapshot          -> mkdir + cp -a       inside the identity dir
seed update       -> sed -i              identity dir/seed.env
wipe              -> rm -f               inside the identity dir
```

Nothing needs elevation: the filesystem work is confined to one directory tree, and the server lifecycle goes over RCON rather than docker or systemd. So this grants group membership instead. A stored sudo credential would be strictly more privilege than the job needs, and would turn a compromise of the panel into a compromise of the host — a bad trade for a product where customers attach their own machines.

## SETGID is load-bearing

`rust_gameserver_identity_dir_mode: '2775'` — the sticky bit is not tidiness. `sed -i` does not edit in place: it writes a temp file and renames over the target, so the replacement belongs to whoever ran it. Without setgid, `seed.env` ends up in the manager's own group and **the container can no longer read its own seed**. Molecule asserts the mode, with that reasoning in the failure message so a future reader doesn't "simplify" it to 0775.

## Changes

- `rust_gameserver_manager_users` (default `[]`) — users appended to the runtime group. Resolved from the numeric PGID via `getent` rather than taking a group name, so it cannot drift from the group the container actually runs as.
- `rust_gameserver_identity_dir_mode` (default `'0755'`, unchanged behaviour).
- `/etc/rust/server/<identity>` is now managed explicitly rather than appearing as a side effect of creating its children — which is what makes that mode mean anything.
- Molecule converge exercises both new variables; verify asserts the directory mode, the setgid bit and the group membership.

`ansible-lint` passes at the production profile. Version bumped to 0.2.0.