### PR TITLE
Mount the game install root on the host so root-level game files are host-visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.0
+* Mount the game install root on the host (`/etc/rust/server/<identity>/install`) so files the game writes to its root — e.g. vanilla `world.rendermap` output, fetched over SSH by rustd.xyz — are host-visible. First boot after adopting the mount re-downloads the game into it; saves/plugins/env mounts are unchanged
+
 ## 0.2.0
 * New `rust_gameserver_manager_users` (default `[]`): host users an external manager (e.g. rustd.xyz) connects as, appended to the container's runtime group so they can write inside the identity directory. Deliberately group membership rather than a sudo grant — such a manager's filesystem work is confined to that one directory tree and it drives the server lifecycle over RCON, so root is never required
 * New `rust_gameserver_identity_dir_mode` (default `'0755'`, unchanged behaviour): set `'2775'` alongside `rust_gameserver_manager_users`. The group-write bit lets the manager create snapshots and delete map/save files; **SETGID is load-bearing** — `sed -i` on `seed.env` replaces the file rather than editing it, and without setgid the replacement lands in the manager's own group, at which point the container can no longer read its own seed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -163,7 +163,7 @@
       - "/etc/rust/server/{{ rust_gameserver_identity }}/install:/steamcmd/rust:rw"
       - "/etc/rust/server/{{ rust_gameserver_identity }}:/steamcmd/rust/server/{{ rust_gameserver_identity }}:rw" # persist save files
       - "/etc/rust/server/{{ rust_gameserver_identity }}/rust.env:/etc/rust/rust.env" # lets us change the env without redeploying container
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redploying container
+      - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redeploying container
       - "/etc/rust/server/{{ rust_gameserver_identity }}/oxide:/steamcmd/rust/oxide"  # plugins / plugin config
       - "/etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data:/steamcmd/rust/RustDedicated_Data" # dll plugins
     ports:

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -79,6 +79,7 @@
     - /etc/rust/server/{{ rust_gameserver_identity }}/cfg
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
+    - /etc/rust/server/{{ rust_gameserver_identity }}/install
 
 # rust.env carries RUST_RCON_PASSWORD — not world-readable. The runtime group can
 # read it (the container entrypoint and dropped game user), other host users cannot.
@@ -153,6 +154,13 @@
     image: ghcr.io/compscidr/rust-server
     pull: true
     volumes:
+      # The whole install root, host-visible per server. Files the game writes to its root —
+      # notably vanilla `world.rendermap` output, which rustd.xyz fetches over SSH — otherwise
+      # exist only in the container's writable layer. The image's entrypoint installs/updates
+      # the game into this dir on boot (first boot after adopting this mount re-downloads the
+      # game), and the narrower mounts below stack on top of it unchanged, so saves, plugins
+      # and env files stay exactly where they already are on the host.
+      - "/etc/rust/server/{{ rust_gameserver_identity }}/install:/steamcmd/rust:rw"
       - "/etc/rust/server/{{ rust_gameserver_identity }}:/steamcmd/rust/server/{{ rust_gameserver_identity }}:rw" # persist save files
       - "/etc/rust/server/{{ rust_gameserver_identity }}/rust.env:/etc/rust/rust.env" # lets us change the env without redeploying container
       - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redploying container


### PR DESCRIPTION
## Problem
`world.rendermap` saves its PNG to the game's install root (`/steamcmd/rust`). That directory was only the container's writable layer, so the file was invisible from the host — rustd.xyz's vanilla map fetch (SSH) failed with no-such-file on the california build server (vanilla, no Oxide, so no plugin fallback).

## Change
Add one volume: `/etc/rust/server/{{ identity }}/install:/steamcmd/rust:rw` (+ create the dir).

- **Per-server host dir** — no collisions when several servers run on one host.
- **Existing mounts unchanged** — the narrower binds (`server/<identity>`, `oxide`, `RustDedicated_Data`, env files) nest on top, so saves/plugins/configs stay exactly where they are today. No data migration.
- The image's entrypoint steamcmd-installs into the empty dir on first boot (one-time ~8 GB download per server), and `CHOWN_DIRS=/steamcmd` already fixes ownership.

## Pairing
rustd.xyz PR compscidr/rustd.xyz#399 adds a per-server "Map render path on host" setting — for the build server, set it to `/etc/rust/server/build/install` after redeploying with this mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)