### PR TITLE
One tree per server: everything lives under /etc/rust/install/<identity> (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
-## 0.3.1
-* **Fix 0.3.0 crash loop**: the install-root host dir moved to `/etc/rust/install/server/<identity>` — hosting it inside the identity dir made the two mounts contain each other (an infinitely deep directory cycle) and the entrypoint's recursive chown killed the container. Do not deploy 0.3.0. Hosts that ran 0.3.0 can remove the orphaned `/etc/rust/server/<identity>/install` dir after redeploying
+## 0.4.0
+* **BREAKING — one tree per server, replacing 0.3.0 (do not deploy 0.3.0: its nested install mount crash-loops the container).** Each server now lives entirely under `/etc/rust/install/<identity>` (var `rust_gameserver_install_dir`), bind-mounted at the container's `/steamcmd/rust`. The game's own layout puts the save/identity dir at `server/<identity>` inside it (var `rust_gameserver_data_dir`); `oxide/` and `RustDedicated_Data/` sit at the tree's root; `rust.env`/`seed.env`/`wipe.sh` live in the identity dir. Root-level game files — vanilla `world.rendermap` output that rustd.xyz fetches over SSH — are now host-visible. Never point two containers at one install dir: concurrent steamcmd updates conflict
+* **Migration from the `/etc/rust/server/<identity>` layout** (per server, before deploying):
+  ```
+  docker stop rust-<identity>
+  mkdir -p /etc/rust/install/<identity>/server
+  mv /etc/rust/server/<identity> /etc/rust/install/<identity>/server/<identity>
+  mv /etc/rust/install/<identity>/server/<identity>/oxide /etc/rust/install/<identity>/oxide
+  mv /etc/rust/install/<identity>/server/<identity>/RustDedicated_Data /etc/rust/install/<identity>/RustDedicated_Data
+  rm -rf /etc/rust/install/<identity>/server/<identity>/install   # 0.3.0 orphan, if present
+  ```
+  then deploy (the container is recreated; steamcmd downloads the game into the tree on first boot, ~8 GB). Point external managers (rustd.xyz) at the new paths: data path `/etc/rust/install/<identity>/server/<identity>`, map render path `/etc/rust/install/<identity>`
 
 ## 0.3.0
 * Mount the game install root on the host (`/etc/rust/server/<identity>/install`) so files the game writes to its root — e.g. vanilla `world.rendermap` output, fetched over SSH by rustd.xyz — are host-visible. First boot after adopting the mount re-downloads the game into it; saves/plugins/env mounts are unchanged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.3.1
+* **Fix 0.3.0 crash loop**: the install-root host dir moved to `/etc/rust/install/<identity>` — hosting it inside the identity dir made the two mounts contain each other (an infinitely deep directory cycle) and the entrypoint's recursive chown killed the container. Do not deploy 0.3.0. Hosts that ran 0.3.0 can remove the orphaned `/etc/rust/server/<identity>/install` dir after redeploying
+
 ## 0.3.0
 * Mount the game install root on the host (`/etc/rust/server/<identity>/install`) so files the game writes to its root — e.g. vanilla `world.rendermap` output, fetched over SSH by rustd.xyz — are host-visible. First boot after adopting the mount re-downloads the game into it; saves/plugins/env mounts are unchanged
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## 0.3.1
-* **Fix 0.3.0 crash loop**: the install-root host dir moved to `/etc/rust/install/<identity>` — hosting it inside the identity dir made the two mounts contain each other (an infinitely deep directory cycle) and the entrypoint's recursive chown killed the container. Do not deploy 0.3.0. Hosts that ran 0.3.0 can remove the orphaned `/etc/rust/server/<identity>/install` dir after redeploying
+* **Fix 0.3.0 crash loop**: the install-root host dir moved to `/etc/rust/install/server/<identity>` — hosting it inside the identity dir made the two mounts contain each other (an infinitely deep directory cycle) and the entrypoint's recursive chown killed the container. Do not deploy 0.3.0. Hosts that ran 0.3.0 can remove the orphaned `/etc/rust/server/<identity>/install` dir after redeploying
 
 ## 0.3.0
 * Mount the game install root on the host (`/etc/rust/server/<identity>/install`) so files the game writes to its root — e.g. vanilla `world.rendermap` output, fetched over SSH by rustd.xyz — are host-visible. First boot after adopting the mount re-downloads the game into it; saves/plugins/env mounts are unchanged

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 [![ansible lint rules](https://img.shields.io/badge/Ansible--lint-rules%20table-blue.svg)](https://ansible.readthedocs.io/projects/lint/rules/)
 
 Enables easy configuration and deployment of rust game servers using
-a docker container. The configs and volumes for save games are stored
-on the host machine via volumes.
+a docker container. Each server's ENTIRE tree — game install, plugins, saves
+and env files — lives on the host under one per-server directory,
+`/etc/rust/install/{{ rust_gameserver_identity }}`, bind-mounted at the
+container's `/steamcmd/rust`. The game's own layout nests the save (identity)
+dir at `server/{{ rust_gameserver_identity }}` inside it. Install dirs must
+never be shared between containers (concurrent steamcmd updates conflict).
 
 The host machine adds a cron job to control the wipe schedule based
 on the configs. The wipe can be weekly, biweekly, or monthly depending
@@ -17,17 +21,17 @@ which is based on the didstopia image with a few upates.
 
 ## Oxide Plugins
 Since there may be multiple servers running on a machine, you can copy plugins 
-to `/etc/rust/server/{{ rust_gameserver_identity }}/oxide/plugins` on the host
+to `/etc/rust/install/{{ rust_gameserver_identity }}/oxide/plugins` on the host
 machine.
 
-Oxide config can be copied to `/etc/rust/server/{{ rust_gameserver_identity }}/oxide/`
+Oxide config can be copied to `/etc/rust/install/{{ rust_gameserver_identity }}/oxide/`
 You may want to do this if you are using oxide plugins, but want to set your config
 to non-modified if you want to show up in the community servers list (note, you
 should only do this if your plugins don't modify game behavior)
 
 ## Dll Plugins
 Plugins like [rust::io](http://playrust.io/manual/#!index.md) should be copied
-to `/etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed`.
+to `/etc/rust/install/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed`.
 
 ## Development
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.3.1
+version: 0.4.0
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,12 +7,12 @@
     - name: Rotate the seed like wipe.sh does
       ansible.builtin.copy:
         content: 'RUST_SERVER_SEED="99999"'
-        dest: /etc/rust/server/test/seed.env
+        dest: /etc/rust/install/test/server/test/seed.env
         mode: '644'
 
     - name: Drift rust.env like an external manager would
       ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
         regexp: '^RUST_SERVER_NAME='
         line: 'RUST_SERVER_NAME="Renamed At Runtime"'
 
@@ -42,13 +42,13 @@
       register: config_dirs
       loop:
         - /etc/rust
-        - /etc/rust/server
-        - /etc/rust/server/test
-        - /etc/rust/server/test/oxide
-        - /etc/rust/server/test/oxide/plugins
-        - /etc/rust/server/test/cfg
-        - /etc/rust/server/test/RustDedicated_Data
-        - /etc/rust/server/test/RustDedicated_Data/Managed
+        - /etc/rust/install
+        - /etc/rust/install/test
+        - /etc/rust/install/test/server/test
+        - /etc/rust/install/test/oxide
+        - /etc/rust/install/test/oxide/plugins
+        - /etc/rust/install/test/RustDedicated_Data
+        - /etc/rust/install/test/RustDedicated_Data/Managed
 
     - name: Assert all directories exist
       ansible.builtin.assert:
@@ -64,9 +64,9 @@
         path: "{{ item }}"
       register: config_files
       loop:
-        - /etc/rust/server/test/rust.env
-        - /etc/rust/server/test/seed.env
-        - /etc/rust/server/test/wipe.sh
+        - /etc/rust/install/test/server/test/rust.env
+        - /etc/rust/install/test/server/test/seed.env
+        - /etc/rust/install/test/server/test/wipe.sh
 
     - name: Assert configuration files exist
       ansible.builtin.assert:
@@ -79,7 +79,7 @@
 
     - name: Verify rust.env contains expected content
       ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
         line: 'RUST_SERVER_NAME="Test Server"'
         state: present
       check_mode: true
@@ -103,7 +103,7 @@
 
     - name: Read seed.env after re-converge
       ansible.builtin.slurp:
-        src: /etc/rust/server/test/seed.env
+        src: /etc/rust/install/test/server/test/seed.env
       register: seed_env_content
 
     - name: Assert the rotated seed survived the re-run (create-only semantics)
@@ -113,7 +113,7 @@
 
     - name: Check rust.env drift was overwritten (default overwrite_env)
       ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
         line: 'RUST_SERVER_NAME="Test Server"'
         state: present
       check_mode: true
@@ -124,9 +124,9 @@
         that:
           - not rust_env_restored.changed
 
-    - name: Stat oxide directory ownership
+    - name: Stat oxide plugins directory ownership
       ansible.builtin.stat:
-        path: /etc/rust/server/test/oxide
+        path: /etc/rust/install/test/oxide/plugins
       register: oxide_dir_stat
 
     - name: Assert identity directories are owned by the runtime user
@@ -137,7 +137,7 @@
 
     - name: Stat rust.env permissions
       ansible.builtin.stat:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
       register: rust_env_stat
 
     - name: Assert rust.env is 640 root:pgid (enforced even on the bootstrap path)
@@ -149,7 +149,7 @@
 
     - name: Stat the identity directory
       ansible.builtin.stat:
-        path: /etc/rust/server/test
+        path: /etc/rust/install/test/server/test
       register: identity_dir_stat
 
     - name: Assert the identity directory is group-writable and setgid

--- a/molecule/external/verify.yml
+++ b/molecule/external/verify.yml
@@ -6,7 +6,7 @@
   tasks:
     - name: Change the server name in rust.env
       ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
         regexp: '^RUST_SERVER_NAME='
         line: 'RUST_SERVER_NAME="Panel Managed Name"'
 
@@ -34,7 +34,7 @@
 
     - name: Check panel-drifted rust.env survived
       ansible.builtin.lineinfile:
-        path: /etc/rust/server/test/rust.env
+        path: /etc/rust/install/test/server/test/rust.env
         line: 'RUST_SERVER_NAME="Panel Managed Name"'
         state: present
       check_mode: true
@@ -47,7 +47,7 @@
 
     - name: Check seed.env still exists
       ansible.builtin.stat:
-        path: /etc/rust/server/test/seed.env
+        path: /etc/rust/install/test/server/test/seed.env
       register: seed_check
 
     - name: Assert seed.env exists (created by first run, untouched after)

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -68,3 +68,14 @@ rust_gameserver_manager_users: []
 # on files it replaces — without it, `sed -i` on seed.env hands the file to the
 # manager's own group and the container can no longer read its own seed.
 rust_gameserver_identity_dir_mode: '0755'
+
+# Where a server's ENTIRE tree lives on the host: the game install root, mounted at
+# /steamcmd/rust in the container. The game's own layout nests the identity (save) dir
+# at server/<identity> inside it, so everything about one server — binaries, plugins,
+# saves, env files — sits under this one directory. Per-server on purpose: install
+# directories cannot be shared between containers (concurrent steamcmd updates and
+# runtime state conflict).
+rust_gameserver_install_dir: "/etc/rust/install/{{ rust_gameserver_identity }}"
+# The identity (save) dir inside the install root — where wipes delete files, seed.env
+# and rust.env live, and an external manager (rustd.xyz) works.
+rust_gameserver_data_dir: "{{ rust_gameserver_install_dir }}/server/{{ rust_gameserver_identity }}"

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -10,7 +10,7 @@
     group: root
   loop:
     - /etc/rust
-    - /etc/rust/server
+    - /etc/rust/install
 
 # The identity directory itself is where an external manager (rustd.xyz) does its
 # work: it creates snapshot subdirectories, rewrites seed.env and deletes map/save
@@ -51,20 +51,11 @@
   loop: "{{ rust_gameserver_manager_users }}"
   when: rust_gameserver_manager_users | length > 0
 
-- name: Create the server identity directory
-  tags: rust_gameserver
-  become: true
-  ansible.builtin.file:
-    path: /etc/rust/server/{{ rust_gameserver_identity }}
-    state: directory
-    mode: "{{ rust_gameserver_identity_dir_mode }}"
-    owner: "{{ rust_gameserver_puid }}"
-    group: "{{ rust_gameserver_pgid }}"
-
-# Per-identity directories are owned by the container's runtime user (PUID/PGID):
-# Oxide and the game server run as that uid and need to CREATE files here (plugin
-# data, compiled artifacts, config rewrites) — root-owned 755 dirs break that.
-- name: Create server identity directories (owned by the runtime user)
+# The install root and its server/ parent come first so their ownership is deliberate:
+# the container's runtime user must be able to CREATE game files here (steamcmd writes
+# the whole install), and letting them appear as implicit parents of the identity dir
+# would leave them root-owned.
+- name: Create the install root (owned by the runtime user)
   tags: rust_gameserver
   become: true
   ansible.builtin.file:
@@ -74,12 +65,35 @@
     owner: "{{ rust_gameserver_puid }}"
     group: "{{ rust_gameserver_pgid }}"
   loop:
-    - /etc/rust/server/{{ rust_gameserver_identity }}/oxide
-    - /etc/rust/server/{{ rust_gameserver_identity }}/oxide/plugins
-    - /etc/rust/server/{{ rust_gameserver_identity }}/cfg
-    - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
-    - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
-    - /etc/rust/install/server/{{ rust_gameserver_identity }}
+    - "{{ rust_gameserver_install_dir }}"
+    - "{{ rust_gameserver_install_dir }}/server"
+
+- name: Create the server identity directory
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.file:
+    path: "{{ rust_gameserver_data_dir }}"
+    state: directory
+    mode: "{{ rust_gameserver_identity_dir_mode }}"
+    owner: "{{ rust_gameserver_puid }}"
+    group: "{{ rust_gameserver_pgid }}"
+
+# Everything else inside the install tree is created by the game/Oxide at runtime —
+# these two exist ONLY so plugins can be copied in (the README's documented pattern)
+# on a fresh host BEFORE the first boot has extracted Oxide; ansible's copy module
+# does not create parent directories.
+- name: Create plugin copy-in directories (owned by the runtime user)
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '755'
+    owner: "{{ rust_gameserver_puid }}"
+    group: "{{ rust_gameserver_pgid }}"
+  loop:
+    - "{{ rust_gameserver_install_dir }}/oxide/plugins"
+    - "{{ rust_gameserver_install_dir }}/RustDedicated_Data/Managed"
 
 # rust.env carries RUST_RCON_PASSWORD — not world-readable. The runtime group can
 # read it (the container entrypoint and dropped game user), other host users cannot.
@@ -88,7 +102,7 @@
   become: true
   ansible.builtin.template:
     src: rust.env.j2
-    dest: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
+    dest: "{{ rust_gameserver_data_dir }}/rust.env"
     mode: '640'
     owner: root
     group: "{{ rust_gameserver_pgid }}"
@@ -101,7 +115,7 @@
   tags: rust_gameserver
   become: true
   ansible.builtin.file:
-    path: /etc/rust/server/{{ rust_gameserver_identity }}/rust.env
+    path: "{{ rust_gameserver_data_dir }}/rust.env"
     mode: '640'
     owner: root
     group: "{{ rust_gameserver_pgid }}"
@@ -114,7 +128,7 @@
   become: true
   ansible.builtin.template:
     src: seed.env.j2
-    dest: /etc/rust/server/{{ rust_gameserver_identity }}/seed.env
+    dest: "{{ rust_gameserver_data_dir }}/seed.env"
     mode: '644'
     owner: root
     group: root
@@ -125,7 +139,7 @@
   become: true
   ansible.builtin.template:
     src: wipe.sh.j2
-    dest: /etc/rust/server/{{ rust_gameserver_identity }}/wipe.sh
+    dest: "{{ rust_gameserver_data_dir }}/wipe.sh"
     mode: '644'
     owner: root
     group: root
@@ -139,7 +153,7 @@
   become: true
   ansible.builtin.cron:
     name: "rust_wipe_{{ rust_gameserver_identity }}"
-    job: "bash /etc/rust/server/{{ rust_gameserver_identity }}/wipe.sh"
+    job: "bash {{ rust_gameserver_data_dir }}/wipe.sh"
     cron_file: "rust_wipe_{{ rust_gameserver_identity }}"
     minute: "{{ rust_gameserver_wipe_minute_of_hour }}"
     hour: "{{ rust_gameserver_wipe_hour_of_day }}"
@@ -154,24 +168,22 @@
     image: ghcr.io/compscidr/rust-server
     pull: true
     volumes:
-      # The whole install root, host-visible per server. Files the game writes to its root —
-      # notably vanilla `world.rendermap` output, which rustd.xyz fetches over SSH — otherwise
-      # exist only in the container's writable layer. The image's entrypoint installs/updates
-      # the game into this dir on boot (first boot after adopting this mount re-downloads the
-      # game), and the narrower mounts below stack on top of it unchanged, so saves, plugins
-      # and env files stay exactly where they already are on the host.
+      # ONE mount: the whole install root, host-visible per server. The game's own layout
+      # places everything about this server inside it — binaries, oxide/, saves at
+      # server/<identity>/ — so files the game writes to its root (notably vanilla
+      # `world.rendermap` output, which rustd.xyz fetches over SSH) exist on the host at
+      # the same relative paths. The image's entrypoint installs/updates the game into
+      # this dir on boot; the first boot after adopting the mount downloads the game.
       #
-      # The host dir deliberately lives OUTSIDE /etc/rust/server/<identity>: the identity dir
-      # is itself mounted INSIDE this root (server/<identity> below), so hosting the root
-      # under the identity dir makes each visible inside the other — an infinitely deep
-      # directory cycle that the entrypoint's recursive chown walks until the container dies
-      # (the 0.3.0 bug).
-      - "/etc/rust/install/server/{{ rust_gameserver_identity }}:/steamcmd/rust:rw"
-      - "/etc/rust/server/{{ rust_gameserver_identity }}:/steamcmd/rust/server/{{ rust_gameserver_identity }}:rw" # persist save files
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/rust.env:/etc/rust/rust.env" # lets us change the env without redeploying container
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redeploying container
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/oxide:/steamcmd/rust/oxide"  # plugins / plugin config
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data:/steamcmd/rust/RustDedicated_Data" # dll plugins
+      # Never point two containers at the same install dir: concurrent steamcmd updates
+      # and runtime state conflict. Per-server dirs are the whole point of this layout.
+      - "{{ rust_gameserver_install_dir }}:/steamcmd/rust:rw"
+      # The entrypoint sources these from /etc/rust/*.env inside the container; the file
+      # binds let a seed or env change apply on the next container restart without a
+      # redeploy. They live in the identity dir so the panel's wipe flow (which rewrites
+      # seed.env inside its data path) keeps working.
+      - "{{ rust_gameserver_data_dir }}/rust.env:/etc/rust/rust.env"
+      - "{{ rust_gameserver_data_dir }}/seed.env:/etc/rust/seed.env"
     ports:
       - "{{ rust_gameserver_port }}:{{ rust_gameserver_port }}"
       - "{{ rust_gameserver_port }}:{{ rust_gameserver_port }}/udp"

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -79,7 +79,7 @@
     - /etc/rust/server/{{ rust_gameserver_identity }}/cfg
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
-    - /etc/rust/install/{{ rust_gameserver_identity }}
+    - /etc/rust/install/server/{{ rust_gameserver_identity }}
 
 # rust.env carries RUST_RCON_PASSWORD — not world-readable. The runtime group can
 # read it (the container entrypoint and dropped game user), other host users cannot.
@@ -166,7 +166,7 @@
       # under the identity dir makes each visible inside the other — an infinitely deep
       # directory cycle that the entrypoint's recursive chown walks until the container dies
       # (the 0.3.0 bug).
-      - "/etc/rust/install/{{ rust_gameserver_identity }}:/steamcmd/rust:rw"
+      - "/etc/rust/install/server/{{ rust_gameserver_identity }}:/steamcmd/rust:rw"
       - "/etc/rust/server/{{ rust_gameserver_identity }}:/steamcmd/rust/server/{{ rust_gameserver_identity }}:rw" # persist save files
       - "/etc/rust/server/{{ rust_gameserver_identity }}/rust.env:/etc/rust/rust.env" # lets us change the env without redeploying container
       - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redeploying container

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -79,7 +79,7 @@
     - /etc/rust/server/{{ rust_gameserver_identity }}/cfg
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data
     - /etc/rust/server/{{ rust_gameserver_identity }}/RustDedicated_Data/Managed
-    - /etc/rust/server/{{ rust_gameserver_identity }}/install
+    - /etc/rust/install/{{ rust_gameserver_identity }}
 
 # rust.env carries RUST_RCON_PASSWORD — not world-readable. The runtime group can
 # read it (the container entrypoint and dropped game user), other host users cannot.
@@ -160,7 +160,13 @@
       # the game into this dir on boot (first boot after adopting this mount re-downloads the
       # game), and the narrower mounts below stack on top of it unchanged, so saves, plugins
       # and env files stay exactly where they already are on the host.
-      - "/etc/rust/server/{{ rust_gameserver_identity }}/install:/steamcmd/rust:rw"
+      #
+      # The host dir deliberately lives OUTSIDE /etc/rust/server/<identity>: the identity dir
+      # is itself mounted INSIDE this root (server/<identity> below), so hosting the root
+      # under the identity dir makes each visible inside the other — an infinitely deep
+      # directory cycle that the entrypoint's recursive chown walks until the container dies
+      # (the 0.3.0 bug).
+      - "/etc/rust/install/{{ rust_gameserver_identity }}:/steamcmd/rust:rw"
       - "/etc/rust/server/{{ rust_gameserver_identity }}:/steamcmd/rust/server/{{ rust_gameserver_identity }}:rw" # persist save files
       - "/etc/rust/server/{{ rust_gameserver_identity }}/rust.env:/etc/rust/rust.env" # lets us change the env without redeploying container
       - "/etc/rust/server/{{ rust_gameserver_identity }}/seed.env:/etc/rust/seed.env" # lets us change the seed without redeploying container

--- a/roles/rust_gameserver/templates/wipe.sh.j2
+++ b/roles/rust_gameserver/templates/wipe.sh.j2
@@ -4,16 +4,16 @@
 # https://www.bisecthosting.com/clients/index.php?rp=/knowledgebase/618/How-to-setup-automatic-server-wipes-on-a-Rust-server.html
 wipe() {
   docker stop rust-{{ rust_gameserver_identity }}
-  rm -f /etc/rust/server/{{ rust_gameserver_identity }}/player.deaths.*
-  rm -f /etc/rust/server/{{ rust_gameserver_identity }}/*.map
-  rm -f /etc/rust/server/{{ rust_gameserver_identity }}/*.sav*
+  rm -f {{ rust_gameserver_data_dir }}/player.deaths.*
+  rm -f {{ rust_gameserver_data_dir }}/*.map
+  rm -f {{ rust_gameserver_data_dir }}/*.sav*
 
   if [ {{ rust_gameserver_wipe_bp }} -eq 1 ]; then
-    rm -f /etc/rust/server/{{ rust_gameserver_identity }}/*.states
-    rm -f /etc/rust/server/{{ rust_gameserver_identity }}/*.blueprints.*
+    rm -f {{ rust_gameserver_data_dir }}/*.states
+    rm -f {{ rust_gameserver_data_dir }}/*.blueprints.*
   fi
 
-  sudo sed -i~ '/^RUST_SERVER_SEED=/s/=.*/='$RANDOM'/' /etc/rust/server/{{ rust_gameserver_identity }}/seed.env
+  sudo sed -i~ '/^RUST_SERVER_SEED=/s/=.*/='$RANDOM'/' {{ rust_gameserver_data_dir }}/seed.env
   docker start rust-{{ rust_gameserver_identity }}
 }
 


### PR DESCRIPTION
## Replaces the 0.3.x mount design entirely (never deploy 0.3.0 — its nested install mount crash-loops the container)

One bind per server: `/etc/rust/install/{{ identity }} → /steamcmd/rust`. The game's own layout then puts everything about the server in that one host tree:

```
/etc/rust/install/build/
├── (game install — steamcmd populates on first boot, ~8 GB)
├── oxide/
├── RustDedicated_Data/
└── server/build/          ← saves, cfg/, rust.env, seed.env, wipe.sh, snapshots
```

- Root-level game files (vanilla `world.rendermap` output, fetched over SSH by rustd.xyz) are host-visible — the original goal.
- `rust.env`/`seed.env` move into the identity dir; their file-binds to `/etc/rust/*.env` remain, and the panel's wipe flow (which rewrites `seed.env` inside its data path) keeps working unchanged.
- The pre-create loop shrinks to the two plugin copy-in dirs ansible must write before first boot; the game/Oxide create everything else.
- New vars `rust_gameserver_install_dir` / `rust_gameserver_data_dir`; setgid/manager-grant re-anchors on the new identity dir; molecule verify plays updated.
- Install dirs must never be shared between containers (concurrent steamcmd updates conflict) — per-server is the point.

## BREAKING — migration (per server, commands in CHANGELOG)
Move `/etc/rust/server/<identity>` into the new tree, lift `oxide/` and `RustDedicated_Data/` to the tree root, delete the 0.3.0 orphan if present, deploy. Then point rustd.xyz at: data path `/etc/rust/install/<identity>/server/<identity>`, map render path `/etc/rust/install/<identity>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)