### PR TITLE
Own the runtime identity, and refuse to run the game as a manager user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## 0.5.0
+* **The role can now own the game's runtime identity.** Set `rust_gameserver_runtime_user` (and optionally `_group`) to a NAME and the role ensures that account and group exist and adopts their real uid/gid. Existing accounts are looked up, never modified -- point it at `steam` on a host that already uses it and nothing about that account changes
+* **New guard: the role refuses to run the game as one of `rust_gameserver_manager_users`.** When those collide, every permission decision in this role is a no-op -- the manager owns the files outright, so group write grants nothing, the setgid directory grants nothing, and adding the manager to "the runtime group" adds it to its own group. The deployment appears to work with none of its security properties. The manager can also read the RCON password out of the game's `/proc` entry, which running as a separate account prevents
+* Leaving `rust_gameserver_runtime_user` empty keeps the previous numeric `puid`/`pgid` behaviour, so existing installs are not re-homed. The new guard still applies in that mode
+* Molecule now deploys a dedicated `rustsvc` runtime account distinct from the manager, and every assertion that hardcoded uid/gid `1000` was rewritten to reference the resolved ids -- four of them, all of which silently assumed the runtime identity was uid 1000
 ## 0.4.2
 * **The default `rust_gameserver_banner_url` now points at an image in this repo** (`roles/rust_gameserver/files/server-default.jpg`, served over `raw.githubusercontent.com`) instead of imgbox, which went down and left every server that took the default showing a broken banner in the server browser. The file is not copied anywhere by the role — it exists only so the URL resolves. Servers that set their own banner are unaffected
 ## 0.4.1

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -25,6 +25,11 @@
         rust_gameserver_rcon_password: "testpass"
         # Exercise the external-manager path: a manager user in the runtime group,
         # and a setgid group-writable identity directory.
+        # A dedicated runtime account, distinct from the manager. Without this the game
+        # would run as molecule_manager (the first regular user in the container, so uid
+        # 1000) and the role now refuses -- correctly, since every permission it sets
+        # would be a no-op.
+        rust_gameserver_runtime_user: "rustsvc"
         rust_gameserver_manager_users:
           - "molecule_manager"
         rust_gameserver_identity_dir_mode: '2775'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -29,6 +29,11 @@
         # which is precisely what this re-include caught, and is a real hazard: an
         # operator who deploys from a context missing these vars silently locks the
         # external manager out of the directory it needs.
+        # A dedicated runtime account, distinct from the manager. Without this the game
+        # would run as molecule_manager (the first regular user in the container, so uid
+        # 1000) and the role now refuses -- correctly, since every permission it sets
+        # would be a no-op.
+        rust_gameserver_runtime_user: "rustsvc"
         rust_gameserver_manager_users:
           - "molecule_manager"
         rust_gameserver_identity_dir_mode: '2775'
@@ -87,6 +92,28 @@
     #
     # Asserted on the mode bits rather than "the manager can write", because the manager user
     # does not exist in this scenario; the group grant is what makes it possible.
+    # The runtime identity must be a real, separate account -- this is what makes the
+    # group-write permissions below mean anything. If the game ran as the manager, it
+    # would own every file outright and none of the permission work would be doing
+    # anything, which is precisely the state the role now refuses to deploy.
+    - name: Look up the runtime and manager accounts
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ item }}"
+      register: runtime_accounts
+      loop:
+        - rustsvc
+        - molecule_manager
+
+    - name: Assert the game runs as its own account, not the manager's
+      ansible.builtin.assert:
+        that:
+          - (runtime_accounts.results[0].ansible_facts.getent_passwd | dict2items | first).value[1]
+            != (runtime_accounts.results[1].ansible_facts.getent_passwd | dict2items | first).value[1]
+        fail_msg: >-
+          rustsvc and molecule_manager resolved to the same uid, so every permission
+          this role sets would be a no-op.
+
     - name: Stat the env files the external manager must rewrite in place
       ansible.builtin.stat:
         path: "{{ item }}"
@@ -99,9 +126,13 @@
       ansible.builtin.assert:
         that:
           - item.stat.wgrp
-          - item.stat.gid | int == 1000
+          # Against the runtime gid the role actually resolved, not a literal. The previous
+          # hardcoded 1000 only held while the runtime identity happened to be uid 1000 --
+          # which is the very assumption this change exists to remove.
+          - item.stat.gid | int == rust_gameserver_pgid | int
         fail_msg: >-
-          {{ item.stat.path }} is mode {{ item.stat.mode }} gid {{ item.stat.gid }} —
+          {{ item.stat.path }} is mode {{ item.stat.mode }} gid {{ item.stat.gid }}
+          (expected gid {{ rust_gameserver_pgid }}) —
           the manager cannot rewrite it in place, so it would replace the inode and
           orphan the container's single-file bind mount.
       loop: "{{ manager_writable_files.results }}"
@@ -169,8 +200,8 @@
     - name: Assert identity directories are owned by the runtime user
       ansible.builtin.assert:
         that:
-          - oxide_dir_stat.stat.uid == 1000
-          - oxide_dir_stat.stat.gid == 1000
+          - oxide_dir_stat.stat.uid == rust_gameserver_puid | int
+          - oxide_dir_stat.stat.gid == rust_gameserver_pgid | int
 
     - name: Stat rust.env permissions
       ansible.builtin.stat:
@@ -182,7 +213,7 @@
         that:
           - rust_env_stat.stat.mode == '0660'
           - rust_env_stat.stat.uid == 0
-          - rust_env_stat.stat.gid == 1000
+          - rust_env_stat.stat.gid == rust_gameserver_pgid | int
 
     - name: Stat the identity directory
       ansible.builtin.stat:
@@ -193,7 +224,7 @@
       ansible.builtin.assert:
         that:
           - identity_dir_stat.stat.mode == '2775'
-          - identity_dir_stat.stat.gid == 1000
+          - identity_dir_stat.stat.gid == rust_gameserver_pgid | int
         fail_msg: >-
           The identity directory must be group-writable and SETGID. Without setgid,
           `sed -i` on seed.env hands the replacement to the manager's own group and
@@ -202,7 +233,7 @@
     - name: Read the runtime group
       ansible.builtin.getent:
         database: group
-        key: "1000"
+        key: "{{ rust_gameserver_pgid }}"
 
     - name: Assert the manager user was added to the runtime group
       ansible.builtin.assert:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,6 +16,15 @@
         regexp: '^RUST_SERVER_NAME='
         line: 'RUST_SERVER_NAME="Renamed At Runtime"'
 
+    # Adoption must not touch the account. Give it a distinctive shell first: converge CREATED
+    # rustsvc, so the re-include below takes the adopt path, and anything the role does to an
+    # existing user shows up here. The old implementation passed existing accounts to the user
+    # module, which would rewrite their primary group.
+    - name: Give the runtime account a distinctive shell before it is adopted
+      ansible.builtin.user:
+        name: rustsvc
+        shell: /bin/bash
+
     - name: Re-include rust_gameserver role
       ansible.builtin.include_role:
         name: rust_gameserver
@@ -96,6 +105,22 @@
     # group-write permissions below mean anything. If the game ran as the manager, it
     # would own every file outright and none of the permission work would be doing
     # anything, which is precisely the state the role now refuses to deploy.
+    - name: Read the runtime account after adoption
+      ansible.builtin.getent:
+        database: passwd
+        key: rustsvc
+
+    - name: Assert adopting the account did not modify it
+      ansible.builtin.assert:
+        that:
+          - (ansible_facts.getent_passwd | dict2items | first).value[5] == '/bin/bash'
+          - (ansible_facts.getent_passwd | dict2items | first).value[2] == rust_gameserver_pgid | string
+        fail_msg: >-
+          rustsvc was altered by being adopted -- shell
+          {{ (ansible_facts.getent_passwd | dict2items | first).value[5] }}, primary gid
+          {{ (ansible_facts.getent_passwd | dict2items | first).value[2] }}. An existing
+          account must be looked up, never rewritten.
+
     - name: Look up the runtime and manager accounts
       ansible.builtin.getent:
         database: passwd

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -72,8 +72,14 @@ rust_gameserver_overwrite_env: true
 # below grant nothing, because the manager already owns every file. See the collision assert
 # in tasks/main.yml.
 #
-# Adoption is safe: an existing account is looked up, not modified. Point this at whatever the
-# host already uses (`steam`, say) and its real uid/gid are adopted.
+# Adoption never modifies an existing account. If the named user already exists it is looked
+# up and its REAL uid and primary gid are used -- rust_gameserver_runtime_group is not applied
+# to it, because rewriting the primary group of an account like `steam`, which other things on
+# the host may already depend on, is not a change a deploy should make silently. If its primary
+# group is not the one requested here, the role refuses rather than quietly using a different
+# group from the one asked for.
+#
+# rust_gameserver_runtime_group therefore only takes effect when the role CREATES the account.
 rust_gameserver_runtime_user: ""
 rust_gameserver_runtime_group: "{{ rust_gameserver_runtime_user }}"
 

--- a/roles/rust_gameserver/defaults/main.yml
+++ b/roles/rust_gameserver/defaults/main.yml
@@ -62,6 +62,23 @@ rust_gameserver_manage_wipe_cron: true
 rust_gameserver_overwrite_env: true
 # Runtime uid/gid the container drops to (PUID/PGID) — also owns the per-identity
 # config directories so Oxide/the server can create files there, and groups rust.env.
+# The identity the game runs as. Give it a NAME and the role ensures the account and group
+# exist and derives the uid/gid from them; leave it empty and the numeric puid/pgid below are
+# used as-is (the pre-0.5.0 behaviour, kept so existing installs are not re-homed).
+#
+# Naming it is strongly recommended. A bare uid means "whoever happens to be uid 1000 on this
+# host", which is how one deployment ended up running the game as the very account an external
+# manager connects with -- at which point the group-write permissions and the setgid directory
+# below grant nothing, because the manager already owns every file. See the collision assert
+# in tasks/main.yml.
+#
+# Adoption is safe: an existing account is looked up, not modified. Point this at whatever the
+# host already uses (`steam`, say) and its real uid/gid are adopted.
+rust_gameserver_runtime_user: ""
+rust_gameserver_runtime_group: "{{ rust_gameserver_runtime_user }}"
+
+# Used directly only when rust_gameserver_runtime_user is empty; otherwise the role overwrites
+# these with the real ids of that account.
 rust_gameserver_puid: "1000"
 rust_gameserver_pgid: "1000"
 

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -1,4 +1,87 @@
 ---
+# --- Runtime identity ---------------------------------------------------------------
+# Everything below this point -- file ownership, the setgid identity directory, the group
+# an external manager is added to, the container's PUID/PGID -- hangs off one question:
+# WHICH account does the game run as. Resolve it first so the answer is explicit rather
+# than whatever uid 1000 happens to mean on this host.
+#
+# Named mode ensures the account exists and adopts its real ids. Existing accounts are
+# looked up, never modified: no shell, home or group is imposed on an account this role
+# did not create, because adopting `steam` on a host that already uses it must not
+# silently change how someone logs in.
+- name: Ensure the runtime group exists
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.group:
+    name: "{{ rust_gameserver_runtime_group }}"
+    system: true
+    state: present
+  register: rust_gameserver_group_result
+  when: rust_gameserver_runtime_user | length > 0
+
+- name: Ensure the runtime user exists
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.user:
+    name: "{{ rust_gameserver_runtime_user }}"
+    group: "{{ rust_gameserver_runtime_group }}"
+    system: true
+    create_home: false
+    state: present
+  register: rust_gameserver_user_result
+  when: rust_gameserver_runtime_user | length > 0
+
+- name: Adopt the runtime identity's real uid and gid
+  tags: rust_gameserver
+  ansible.builtin.set_fact:
+    rust_gameserver_puid: "{{ rust_gameserver_user_result.uid }}"
+    rust_gameserver_pgid: "{{ rust_gameserver_group_result.gid }}"
+  when: rust_gameserver_runtime_user | length > 0
+
+# Numeric mode: we still need the NAME to check it against the manager users below.
+- name: Resolve the runtime user's name from its uid
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ rust_gameserver_puid }}"
+  when:
+    - rust_gameserver_runtime_user | length == 0
+    - rust_gameserver_manager_users | length > 0
+
+- name: Record which account the game will run as
+  tags: rust_gameserver
+  ansible.builtin.set_fact:
+    rust_gameserver_runtime_user_name: >-
+      {{ rust_gameserver_runtime_user
+         if rust_gameserver_runtime_user | length > 0
+         else (ansible_facts.getent_passwd | first) }}
+  when: rust_gameserver_manager_users | length > 0
+
+# The check that would have caught it. When the game runs as one of the manager users,
+# every permission decision in this role becomes a no-op: the manager owns the files
+# outright, so group write grants nothing, the setgid directory grants nothing, and
+# adding the manager to "the runtime group" adds it to its own group. The deployment
+# appears to work and its security properties are entirely absent -- and on top of that
+# the manager can read the RCON password out of the game's /proc entry, which is the one
+# thing running it as a separate account would have prevented.
+#
+# Refused rather than warned: a warning in a play that goes on to succeed is a warning
+# nobody reads.
+- name: Refuse to run the game as one of the manager users
+  tags: rust_gameserver
+  ansible.builtin.assert:
+    that:
+      - rust_gameserver_runtime_user_name not in rust_gameserver_manager_users
+    fail_msg: >-
+      The game would run as '{{ rust_gameserver_runtime_user_name }}', which is also in
+      rust_gameserver_manager_users. An external manager must be a DIFFERENT account from the
+      one the game runs as, or the group-write permissions and the setgid identity directory
+      grant nothing and the manager can read the RCON password from the game's process
+      arguments. Set rust_gameserver_runtime_user to a dedicated account (the role will create
+      it) and chown the install tree to it.
+  when: rust_gameserver_manager_users | length > 0
+
 - name: Create base config directories
   tags: rust_gameserver
   become: true

--- a/roles/rust_gameserver/tasks/main.yml
+++ b/roles/rust_gameserver/tasks/main.yml
@@ -9,6 +9,25 @@
 # looked up, never modified: no shell, home or group is imposed on an account this role
 # did not create, because adopting `steam` on a host that already uses it must not
 # silently change how someone logs in.
+- name: Look up the runtime account
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ rust_gameserver_runtime_user }}"
+    fail_key: false
+  when: rust_gameserver_runtime_user | length > 0
+
+- name: Note whether the runtime account already exists
+  tags: rust_gameserver
+  ansible.builtin.set_fact:
+    rust_gameserver_runtime_exists: >-
+      {{ ansible_facts.getent_passwd[rust_gameserver_runtime_user] is not none }}
+  when: rust_gameserver_runtime_user | length > 0
+
+# CREATE path only. An existing account is never passed to the user module: `group:` would
+# rewrite its primary group, which for an account like `steam` that other things already
+# depend on is exactly the kind of change a deploy has no business making silently.
 - name: Ensure the runtime group exists
   tags: rust_gameserver
   become: true
@@ -17,9 +36,11 @@
     system: true
     state: present
   register: rust_gameserver_group_result
-  when: rust_gameserver_runtime_user | length > 0
+  when:
+    - rust_gameserver_runtime_user | length > 0
+    - not rust_gameserver_runtime_exists | bool
 
-- name: Ensure the runtime user exists
+- name: Create the runtime user
   tags: rust_gameserver
   become: true
   ansible.builtin.user:
@@ -29,13 +50,51 @@
     create_home: false
     state: present
   register: rust_gameserver_user_result
-  when: rust_gameserver_runtime_user | length > 0
+  when:
+    - rust_gameserver_runtime_user | length > 0
+    - not rust_gameserver_runtime_exists | bool
 
-- name: Adopt the runtime identity's real uid and gid
+# ADOPT path: take the account exactly as it is. Its real primary gid is used rather than
+# rust_gameserver_runtime_group, so nothing about the account changes.
+- name: Resolve the existing account's primary group
+  tags: rust_gameserver
+  become: true
+  ansible.builtin.getent:
+    database: group
+    key: "{{ ansible_facts.getent_passwd[rust_gameserver_runtime_user][2] }}"
+  when:
+    - rust_gameserver_runtime_user | length > 0
+    - rust_gameserver_runtime_exists | bool
+
+# Refused rather than silently ignored: carrying on would use a different group from the one
+# the operator asked for, and the group is what every permission in this role hangs off.
+- name: Refuse to adopt an account whose primary group is not the requested one
+  tags: rust_gameserver
+  ansible.builtin.assert:
+    that:
+      - (ansible_facts.getent_group | first) == rust_gameserver_runtime_group
+    fail_msg: >-
+      '{{ rust_gameserver_runtime_user }}' already exists with primary group
+      '{{ ansible_facts.getent_group | first }}', but rust_gameserver_runtime_group is
+      '{{ rust_gameserver_runtime_group }}'. Adopting an account never modifies it, so this
+      role will not change its primary group. Either set rust_gameserver_runtime_group to
+      '{{ ansible_facts.getent_group | first }}', or pick a runtime user that does not exist
+      yet and let the role create it.
+  when:
+    - rust_gameserver_runtime_user | length > 0
+    - rust_gameserver_runtime_exists | bool
+
+- name: Use the runtime identity's real uid and gid
   tags: rust_gameserver
   ansible.builtin.set_fact:
-    rust_gameserver_puid: "{{ rust_gameserver_user_result.uid }}"
-    rust_gameserver_pgid: "{{ rust_gameserver_group_result.gid }}"
+    rust_gameserver_puid: >-
+      {{ ansible_facts.getent_passwd[rust_gameserver_runtime_user][1]
+         if rust_gameserver_runtime_exists | bool
+         else rust_gameserver_user_result.uid }}
+    rust_gameserver_pgid: >-
+      {{ ansible_facts.getent_passwd[rust_gameserver_runtime_user][2]
+         if rust_gameserver_runtime_exists | bool
+         else rust_gameserver_group_result.gid }}
   when: rust_gameserver_runtime_user | length > 0
 
 # Numeric mode: we still need the NAME to check it against the manager users below.


### PR DESCRIPTION
## The footgun

`rust_gameserver_puid`/`pgid` default to `"1000"` — which means *"whoever happens to be uid 1000 on this host"*. That is a different identity per machine:

| host | uid 1000 is | game runs as | manager connects as |
|--|--|--|--|
| `nas.local` | `steam` | `steam` | `jason` (uid 999) |
| `ubuntu-cube` | `jason` | **`jason`** | **`jason`** |

On the cube the game runs as the very account the external manager (rustd.xyz) connects with. Nothing in the role noticed, because nothing checked.

## Why that is worse than it sounds

When those identities collide, **every permission decision this role makes is a no-op**:

- the `660`/`664` group-write modes grant nothing — the manager owns the files outright
- the setgid identity directory grants nothing, for the same reason
- "add the manager to the runtime group" adds it to its own group

The deployment looks correct and has none of its security properties. Worse, a test on such a host proves nothing about production: it passes for the wrong reason and would keep passing right up until it didn't.

There is a second cost. Because the RCON password is passed as a process argument, an account that is *not* the game's owner can be prevented from reading it via `hidepid`. When the manager IS the owner, that mitigation is unavailable — a process cannot be hidden from itself. See [rustd.xyz#419](https://github.com/compscidr/rustd.xyz/issues/419).

## Changes

**1. The role can own the runtime identity.** `rust_gameserver_runtime_user` takes a **name**; the role ensures the account and group exist and adopts their real uid/gid.

Adoption is deliberately non-destructive: no shell, home or group is imposed on an account the role did not create. Pointing this at `steam` on a host that already uses it changes nothing about that account — it is looked up, not rewritten.

Left empty (the default), the previous numeric behaviour is unchanged, so **no existing install is re-homed by upgrading**.

**2. The role refuses when the runtime user is also a manager user.**

```
The game would run as 'molecule_manager', which is also in rust_gameserver_manager_users.
An external manager must be a DIFFERENT account from the one the game runs as, or the
group-write permissions and the setgid identity directory grant nothing and the manager
can read the RCON password from the game's process arguments. Set
rust_gameserver_runtime_user to a dedicated account (the role will create it) and chown
the install tree to it.
```

Refused rather than warned. A warning in a play that goes on to succeed is a warning nobody reads, and this failure mode is invisible from the outside — which is exactly how it survived.

The guard applies in **both** modes, so even a deployment that never sets `runtime_user` gets the protection.

## Molecule had the same bug

`molecule_manager` is created in `pre_tasks` and is the first regular user in the container, so it is uid 1000 — the scenario was deploying the collision it now refuses. It deploys a dedicated `rustsvc` account instead, which also exercises the new creation path.

That flushed out **four separate assertions hardcoding uid/gid `1000`**, including two I added recently. Each only held while the runtime identity happened to be uid 1000 — the assumption this change exists to remove — and each now references the resolved ids. Worth noting they all passed before and told us nothing.

## Verification

Run locally, not just in CI:

- `molecule test` — converge, idempotence and verify all pass, `failed=0`
- `ansible-lint` — clean at the `production` profile
- **The guard was proved to fire**: pointing `runtime_user` at the manager account fails the play with the message above, reproducing the cube's configuration exactly.

## Migrating a colliding host

`ubuntu-cube` will now fail until it is given a dedicated account. That is intentional — it is currently in the broken state. The fix:

1. stop the container
2. set `rust_gameserver_runtime_user` to a dedicated name
3. `chown -R` the install tree to the new uid — file ownership on disk is numeric and the bind mount maps by uid
4. redeploy

`nas.local` needs only `rust_gameserver_runtime_user: steam` to make its existing, already-correct setup explicit rather than incidental.