### PR TITLE
Bump galaxy.yml to 0.5.0 to match the changelog

### DIFF
--- a/.github/scripts/check-version.sh
+++ b/.github/scripts/check-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# galaxy.yml's version and the newest CHANGELOG heading must agree.
+#
+# This exists because they silently disagreed once: two PRs changed the same `version:` line,
+# the merge resolved it in favour of one side and kept the other's changelog entry, and the
+# result was a valid-looking file that could not be released. A version conflict is the one
+# kind that does NOT leave a marker for someone to resolve, so nothing surfaced it.
+set -euo pipefail
+
+galaxy=$(sed -n 's/^version:[[:space:]]*["'"'"']\{0,1\}\([0-9][^"'"'"']*\)["'"'"']\{0,1\}[[:space:]]*$/\1/p' galaxy.yml | head -1)
+changelog=$(sed -n 's/^##[[:space:]]\{1,\}\([0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\).*$/\1/p' CHANGELOG.md | head -1)
+
+if [ -z "$galaxy" ]; then
+  echo "could not read a version from galaxy.yml" >&2
+  exit 1
+fi
+if [ -z "$changelog" ]; then
+  echo "could not find a '## x.y.z' heading in CHANGELOG.md" >&2
+  exit 1
+fi
+
+if [ "$galaxy" != "$changelog" ]; then
+  cat >&2 <<EOF
+galaxy.yml says $galaxy but the newest CHANGELOG.md heading is $changelog.
+
+Whichever is right, they have to agree or the release is cut at the wrong
+version -- or cannot be cut at all. If a merge resolved the version line in
+favour of the other branch, this is that.
+EOF
+  exit 1
+fi
+
+echo "version OK: galaxy.yml and CHANGELOG.md both say $galaxy"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: galaxy.yml version matches the newest CHANGELOG heading
+        run: ./.github/scripts/check-version.sh
+
   lint:
     name: Ansible Lint
     runs-on: ubuntu-latest

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: A collection of roles to configure and deploy a rust game server. I
   Can be configured to wipe or leave the blueprints during wipe.
 license_file: LICENSE
 readme: README.md
-version: 0.4.2
+version: 0.5.0
 repository: https://github.com/compscidr/ansible-rust-gameserver
 tags:
   - rust


### PR DESCRIPTION
#30 shipped the runtime-identity work along with its `## 0.5.0` changelog entry, but `galaxy.yml` stayed at `0.4.2` — so the release cannot be cut.

## How it slipped

My branch changed that line `0.4.1 → 0.5.0`. #29 merged first and changed the **same line** `0.4.1 → 0.4.2`. Merging #30 resolved the conflict in favour of `main` while keeping my changelog entry, so the two ended up disagreeing:

```
galaxy.yml:  version: 0.4.2
CHANGELOG.md: ## 0.5.0   <- documents #30
              ## 0.4.2   <- documents #29
```

Nothing failed, because the version is not asserted anywhere — it is the one file where a merge can silently pick a side and leave the repo self-contradictory.

`0.4.2` was the last release, so `0.5.0` is the right next number. The changelog ordering is already correct and needs no change.

## Worth considering separately

A check that `galaxy.yml`'s version matches the newest `## x.y.z` heading in `CHANGELOG.md` would catch this class of thing in CI. It is the second time a version-adjacent detail has gone through unnoticed on this repo, and unlike most merge conflicts this one produces a valid-looking file rather than a marker someone has to resolve. Happy to add it if you want it.